### PR TITLE
Added backwards compatibility for Laravel 5.8, 6 & 7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "php": "^7.3",
-        "illuminate/support": "^7.0.6"
+        "php": "^7.2",
+        "illuminate/support": "~5.8.0|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.3"


### PR DESCRIPTION
Closes #24
Downgraded requirement to PHP 7.2 minimum.